### PR TITLE
Refactor registry route configuration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,11 @@ jobs:
           args: 'check'
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        instance:
+          - defaults
+          - minimal
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -37,9 +42,14 @@ jobs:
         with:
           path: ${{ env.COMPONENT_NAME }}
       - name: Compile component
-        run: make test
+        run: make test -e instance=${{ matrix.instance }}
   golden:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        instance:
+          - defaults
+          - minimal
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -48,4 +58,4 @@ jobs:
         with:
           path: ${{ env.COMPONENT_NAME }}
       - name: Golden diff
-        run: make golden-diff
+        run: make golden-diff -e instance=${{ matrix.instance }}

--- a/.sync.yml
+++ b/.sync.yml
@@ -6,3 +6,12 @@
 docs/antora.yml:
   name: openshift4-registry
   title: OpenShift 4 Registry
+
+.github/workflows/test.yml:
+  test_makeTarget: test -e instance=${{ matrix.instance }}
+  goldenTest_makeTarget: golden-diff -e instance=${{ matrix.instance }}
+  matrix:
+    key: instance
+    entries:
+      - defaults
+      - minimal

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -13,3 +13,6 @@ parameters:
     pruning:
       keepTagRevisions: 3
       suspend: false
+    routes: {}
+    secrets: {}
+    cert_manager_certs: {}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -13,6 +13,7 @@ parameters:
     pruning:
       keepTagRevisions: 3
       suspend: false
+    preferredRegistryRoute: ~
     routes: {}
     secrets: {}
     cert_manager_certs: {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -32,22 +32,25 @@ local registryConfigSpec =
       },
     },
   },
-  '10_image_registry': kube._Object(versionGroup, 'Config', 'cluster') {
-    spec+: registryConfigSpec,
-  },
-  '20_image_pruning': kube._Object(versionGroup, 'ImagePruner', 'cluster') {
-    spec+: params.pruning,
-  },
-  [if std.objectHas(params, 's3Credentials') then '30_s3_credentials']: kube.Secret('image-registry-private-configuration-user') {
-    metadata+: {
-      namespace: params.namespace,
+  '10_image_registry':
+    kube._Object(versionGroup, 'Config', 'cluster') {
+      spec+: registryConfigSpec,
     },
-    // stringData because password comes from secret ref
-    stringData: {
-      REGISTRY_STORAGE_S3_ACCESSKEY: params.s3Credentials.accessKey,
-      REGISTRY_STORAGE_S3_SECRETKEY: params.s3Credentials.secretKey,
+  '20_image_pruning':
+    kube._Object(versionGroup, 'ImagePruner', 'cluster') {
+      spec+: params.pruning,
     },
-  },
+  [if std.objectHas(params, 's3Credentials') then '30_s3_credentials']:
+    kube.Secret('image-registry-private-configuration-user') {
+      metadata+: {
+        namespace: params.namespace,
+      },
+      // stringData because password comes from secret ref
+      stringData: {
+        REGISTRY_STORAGE_S3_ACCESSKEY: params.s3Credentials.accessKey,
+        REGISTRY_STORAGE_S3_SECRETKEY: params.s3Credentials.secretKey,
+      },
+    },
   [if std.length(tls.secrets) > 0 then '30_secrets']:
     tls.secrets,
   [if std.length(tls.certs) > 0 then '30_cert_manager_certs']:

--- a/component/tls.libsonnet
+++ b/component/tls.libsonnet
@@ -1,0 +1,60 @@
+local cm = import 'lib/cert-manager.libsonnet';
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_registry;
+
+local isTlsSecret(secret) =
+  local secretKeys = std.set(std.objectFields(secret.stringData));
+  local keyDiff = std.setDiff(secretKeys, std.set([
+    'ca.crt',
+    'tls.crt',
+    'tls.key',
+  ]));
+  secret.type == 'kubernetes.io/tls' && std.length(keyDiff) == 0;
+
+local secrets = std.filter(
+  function(it) it != null,
+  [
+    local scontent = params.secrets[s];
+    local secret = kube.Secret(s) {
+      type: 'kubernetes.io/tls',
+      metadata+: {
+        // Secrets must be deployed in namespace openshift-image-registry
+        namespace: 'openshift-image-registry',
+      },
+    } + com.makeMergeable(scontent);
+    if scontent != null then
+      if isTlsSecret(secret) then
+        secret
+      else
+        error "Invalid secret definition for key '%s'. This component expects secret definitions which are valid for kubernetes.io/tls secrets." % s
+    for s in std.objectFields(params.secrets)
+  ]
+);
+
+local certs = std.filter(
+  function(it) it != null,
+  [
+    local cert = params.cert_manager_certs[c];
+    if cert != null then
+      cm.cert(c) {
+        metadata+: {
+          // Certificates must be deployed in namespace
+          // openshift-image-registry
+          namespace: 'openshift-image-registry',
+        },
+        spec+: {
+          secretName: '%s' % c,
+        },
+      } + com.makeMergeable(cert)
+    for c in std.objectFields(params.cert_manager_certs)
+  ]
+);
+
+{
+  certs: certs,
+  secrets: secrets,
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,22 +10,24 @@ type:: dictionary
 default:: Default image registry.
 
 A dictionary holding the `.spec` for the image registry config.
+The component will overwrite `config.routes` with the processed contents of parameter <<_routes,`routes`>> if that parameter exists.
 
 See the https://docs.openshift.com/container-platform/latest/registry/configuring-registry-operator.html#registry-operator-configuration-resource-overview_configuring-registry-operator[OpenShift docs] for available parameters.
 
 
-=== `routes`
+=== `config.routes`
 
 [horizontal]
 type:: array
 default:: undefined
 
-To create custom routes for exposing the registry, create an entry in this array (see <<Example>>).
-The `secretName` can be used to specify a custom TLS certificate.
-By default it uses the default wildcard certificate of the router.
+[WARNING]
+====
+Using this parameter is deprecated starting from component version v1.0.0.
+Use parameter <<_routes,`openshift4_registry.routes`>> to configure custom routes for the registry instead.
+====
 
-
-=== `storage`
+=== `config.storage`
 
 [horizontal]
 type:: dictionary
@@ -36,6 +38,63 @@ Configure the registry storage based on the cloud provider.
 It's suggested to define this higher up the config hierarchy.
 Most probably the one of the cloud region.
 
+
+== `routes`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+To create custom routes for exposing the registry, create entries in this array (see <<Example>>).
+Each value of the dictionary should be another dictionary.
+Keys `hostname` and `secretName` can be used to configure the hostname and TLS secret for each entry
+
+Each entry in the dictionary is transformed into an entry in the image registry config `.spec.routes` array.
+The key of each entry are used as the value for field `name` of the resulting entry in `.spec.routes`.
+If key `secretName` isn't provided for an entry, the router's default wildcard certificate is used for that route.
+
+== `preferredRegistryRoute`
+
+[horizontal]
+type:: string
+default:: `~` (null)
+
+This parameter can be used to specify which route's hostname should be used in the field `.status.publicDockerImageRepository` of `ImageStream` resources.
+The parameter should be set to a key which is present in parameter `routes`.
+If the default value inferred by the cluster should be used, leave the value of this parameter set to `null`.
+
+If the value of the parameter doesn't match a key in parameter `routes`, the component will print a warning and ignore the configuration.
+
+== `secrets`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+Each entry in parameter `secrets` is deployed onto the cluster as a Kubernetes Secret with `type=kubernetes.io/tls`.
+Entries with `null` values are skipped.
+This allows users to remove secrets which were configured higher up in the hierarchy.
+All secrets are deployed in namespace `openshift-image-registry`.
+
+The component has basic validation to ensure the secret contents are a plausible Kubernetes TLS secret.
+
+The dictionary keys are used as `metadata.name` for the resulting `Secret` resources.
+The dictionary values are directly merged into a `Secret` resource which only has `type=kubernetes.io/tls` set.
+The secrets are created in the namespace indicated by parameter `namespace`.
+
+== `cert_manager_certs`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+Each entry in parameter `cert_manager_certs` is deployed onto the cluster as a cert-manager `Certificate` resource.
+Entries with `null` values are skipped.
+This allows users to remove certificates which were configured higher up in the hierarchy.
+All `Certificate` resources are deployed in namespace `openshift-image-registry`.
+
+The dictionary keys are used as `metadata.name` and `spec.secretName` for the resulting `Certificate` resources.
+The dictionary values are then directly directly merged into the mostly empty `Certificate` resources.
 
 == `pruning`
 
@@ -49,7 +108,7 @@ See the https://docs.openshift.com/container-platform/latest/applications/prunin
 
 To disable image pruning, set the paramteter `pruning.suspend` to `true`.
 
-== 's3Credentials`
+== `s3Credentials`
 
 [horizontal]
 type:: dictionary
@@ -81,11 +140,28 @@ Secret key for an S3 type storage.
 ----
 parameters:
   openshift4_registry:
+    routes: <1>
+      primary-route:
+        hostname: registry.example.com
+        secretName: primary-route-tls
+      secondary-route:
+        hostname: registry.cluster.example.org
+        secretName: secondary-route-tls
+    preferredRegistryRoute: primary-route <2>
+    cert_manager_certs:
+      primary-route-tls: <3>
+        spec:
+          dnsNames:
+            - registry.example.com
+          issuerRef:
+            kind: ClusterIssuer
+            name: letsencrypt-staging
+    secrets:
+      secondary-route-tls: <4>
+        stringData:
+          tls.key: '?{vaultkv:...}'
+          tls.crt: '?{vaultkv:...}'
     config:
-      routes:
-        - name: example-route
-          hostname: registry.example.com
-          secretName: example-route-tls
       storage:
         s3:
           bucket: ${cluster:name}-image-registry
@@ -97,3 +173,19 @@ parameters:
     pruning:
       schedule: '13 */2 * * *'
 ----
+<1> Configure routes in top-level parameter `routes`.
+This configuration will result in the following contents for `config.routes`:
++
+[source,yaml]
+----
+- name: primary-route
+  hostname: registry.example.com
+  secretName: primary-route-tls
+- name: secondary-route
+  hostname: registry.cluster.example.org
+  secretName: secondary-route-tls
+----
+<2> This configuration ensures that `ImageStream` resources on the cluster will have `registry.example.com` as hostname in their `publicDockerImageRepository` value.
+<3> Configure a cert-manager `Certificate` resource to generate the TLS secret for route `primary-route`.
+<4> Directly configure a TLS secret for route `secondary-route`.
+As shown in the example, the TLS key and certificate can be fetched from Vault by using secret references.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -45,12 +45,12 @@ Most probably the one of the cloud region.
 type:: dictionary
 default:: `{}`
 
-To create custom routes for exposing the registry, create entries in this array (see <<Example>>).
+To create custom routes for exposing the registry, create entries in this dictionary (see <<Example>>).
 Each value of the dictionary should be another dictionary.
-Keys `hostname` and `secretName` can be used to configure the hostname and TLS secret for each entry
+Keys `hostname` and `secretName` can be used to configure the hostname and TLS secret for each entry.
 
 Each entry in the dictionary is transformed into an entry in the image registry config `.spec.routes` array.
-The key of each entry are used as the value for field `name` of the resulting entry in `.spec.routes`.
+The key of each entry is used as the value for field `name` of the resulting entry in `.spec.routes`.
 If key `secretName` isn't provided for an entry, the router's default wildcard certificate is used for that route.
 
 == `preferredRegistryRoute`

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,1 +1,28 @@
----
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-cert-manager/v2.2.0/lib/cert-manager.libsonnet
+        output_path: vendor/lib/cert-manager.libsonnet
+
+  openshift4_registry:
+    routes:
+      registry-route:
+        hostname: registry.cluster.example.org
+        secretName: registry-route-tls
+
+    cert_manager_certs:
+      registry-route-tls:
+        spec:
+          dnsNames:
+            - registry.cluster.example.org
+          issuerRef:
+            name: letsencrypt-staging
+            kind: ClusterIssuer
+
+    secrets:
+      alt-route-tls:
+        stringData:
+          tls.crt: 'certificate data'
+          tls.key: 'certificate key vault ref'
+          ca.crt: 'ca certificate data'

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -6,10 +6,15 @@ parameters:
         output_path: vendor/lib/cert-manager.libsonnet
 
   openshift4_registry:
+    preferredRegistryRoute: registry-route
+
     routes:
       registry-route:
         hostname: registry.cluster.example.org
         secretName: registry-route-tls
+      alt-route:
+        hostname: alt-registry.cluster.example.org
+        secretName: alt-route-tls
 
     cert_manager_certs:
       registry-route-tls:

--- a/tests/golden/defaults/openshift4-registry/openshift4-registry/10_image_config.yaml
+++ b/tests/golden/defaults/openshift4-registry/openshift4-registry/10_image_config.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  annotations: {}
+  labels:
+    name: cluster
+  name: cluster
+spec:
+  externalRegistryHostnames:
+    - registry.cluster.example.org

--- a/tests/golden/defaults/openshift4-registry/openshift4-registry/10_image_registry.yaml
+++ b/tests/golden/defaults/openshift4-registry/openshift4-registry/10_image_registry.yaml
@@ -14,6 +14,9 @@ spec:
   replicas: 2
   rolloutStrategy: RollingUpdate
   routes:
+    - hostname: alt-registry.cluster.example.org
+      name: alt-route
+      secretName: alt-route-tls
     - hostname: registry.cluster.example.org
       name: registry-route
       secretName: registry-route-tls

--- a/tests/golden/defaults/openshift4-registry/openshift4-registry/10_image_registry.yaml
+++ b/tests/golden/defaults/openshift4-registry/openshift4-registry/10_image_registry.yaml
@@ -13,4 +13,8 @@ spec:
     node-role.kubernetes.io/infra: ''
   replicas: 2
   rolloutStrategy: RollingUpdate
+  routes:
+    - hostname: registry.cluster.example.org
+      name: registry-route
+      secretName: registry-route-tls
   storage: {}

--- a/tests/golden/defaults/openshift4-registry/openshift4-registry/30_cert_manager_certs.yaml
+++ b/tests/golden/defaults/openshift4-registry/openshift4-registry/30_cert_manager_certs.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations: {}
+  labels:
+    name: registry-route-tls
+  name: registry-route-tls
+  namespace: openshift-image-registry
+spec:
+  dnsNames:
+    - registry.cluster.example.org
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-staging
+  secretName: registry-route-tls

--- a/tests/golden/defaults/openshift4-registry/openshift4-registry/30_secrets.yaml
+++ b/tests/golden/defaults/openshift4-registry/openshift4-registry/30_secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: alt-route-tls
+  name: alt-route-tls
+  namespace: openshift-image-registry
+stringData:
+  ca.crt: ca certificate data
+  tls.crt: certificate data
+  tls.key: certificate key vault ref
+type: kubernetes.io/tls

--- a/tests/golden/minimal/openshift4-registry/openshift4-registry/00_namespace.yaml
+++ b/tests/golden/minimal/openshift4-registry/openshift4-registry/00_namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: openshift-image-registry
+  name: openshift-image-registry

--- a/tests/golden/minimal/openshift4-registry/openshift4-registry/10_image_registry.yaml
+++ b/tests/golden/minimal/openshift4-registry/openshift4-registry/10_image_registry.yaml
@@ -1,0 +1,16 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  annotations: {}
+  labels:
+    name: cluster
+  name: cluster
+spec:
+  httpSecret: t-silent-test-1234/c-green-test-1234/registry/httpSecret
+  logging: 2
+  managementState: Managed
+  nodeSelector:
+    node-role.kubernetes.io/infra: ''
+  replicas: 2
+  rolloutStrategy: RollingUpdate
+  storage: {}

--- a/tests/golden/minimal/openshift4-registry/openshift4-registry/20_image_pruning.yaml
+++ b/tests/golden/minimal/openshift4-registry/openshift4-registry/20_image_pruning.yaml
@@ -1,0 +1,10 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: ImagePruner
+metadata:
+  annotations: {}
+  labels:
+    name: cluster
+  name: cluster
+spec:
+  keepTagRevisions: 3
+  suspend: false

--- a/tests/minimal.yml
+++ b/tests/minimal.yml
@@ -1,0 +1,2 @@
+parameters:
+  openshift4_registry: {}


### PR DESCRIPTION
This commit introduces support for configuring registry routes via component parameter `routes`. Additionally, the commit introduces component parameters `secrets` and `cert_manager_certs` which allow users to configure arbitrary TLS secrets either directly as Secret resources or via cert-manager.

If the parameter `routes` is empty, the component keeps the contents of the provided parameter `config.routes`, otherwise those contents are overwritten by the routes defined in parameter `routes`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x]  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Extend golden tests

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
